### PR TITLE
Rajout d'une condition

### DIFF
--- a/main/measure.ino
+++ b/main/measure.ino
@@ -89,7 +89,7 @@ float calculateCurrent(String filename, int currentAnalogInputPin, int calibrati
       RMSCurrentMean = sqrt(currentMean);   //RMS : Root mean square -> racine carré                    
       FinalRMSCurrent = (((RMSCurrentMean / 1023) * supplyVoltage) / mVperAmpValue) - manualOffset;
 
-      if(FinalRMSCurrent <= (625/mVperAmpValue/100)){ 
+      if(FinalRMSCurrent <= (625/mVperAmpValue/100)) or  (FinalRMSCurrent >30)){ //c'est aussi une erreur vu les capacités du courant 
         //if the current detected is less than or up to 1%, set current value to 0A
         FinalRMSCurrent =0; 
       }     


### PR DESCRIPTION
Si on a une valeur pour le courant supérieur à 30A, ce n'est pas bon non plus. -> On le fais égaler à 0. On pourrait le mettre sous forme de texte "Overload" mais cela rentrerait créerait pe un conflit avec le parsing/format